### PR TITLE
Lap1.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,2 @@
 # basic-informatics
 # A list of basic informatics skills (Python)
-
-### <span style="color:blue">Tugas #1: Pasfoto Praktikan &#8594; 15 poin</span>
-
-Untuk menyisipkan suatu gambar di dalam dokumen Jupyter Notebook, ukuran gambar menjadi sesuatu yang perlu diperhatikan  agar hasil penyisipan tidak terkesan terlalu kecil atau telalu besar dibandingkan bidang tampilan dokumen. Sebagai acuan umum, panjang dan/atau lebar gambar sebaiknya sekitar 300 piksel.


### PR DESCRIPTION
### <span style="color:blue">Tugas #1: Pasfoto Praktikan &#8594; 15 poin</span>

Untuk menyisipkan suatu gambar di dalam dokumen Jupyter Notebook, ukuran gambar menjadi sesuatu yang perlu diperhatikan  agar hasil penyisipan tidak terkesan terlalu kecil atau telalu besar dibandingkan bidang tampilan dokumen. Sebagai acuan umum, panjang dan/atau lebar gambar sebaiknya sekitar 300 piksel.